### PR TITLE
Add steem4everyone support for createPost operation

### DIFF
--- a/includes/class-steem-for-wordpress-settings.php
+++ b/includes/class-steem-for-wordpress-settings.php
@@ -199,21 +199,21 @@ class Steem_for_Wordpress_Settings
   private function settings_fields()
   {
 
-    $settings['steem'] = array(
-      'title'       => __('Steem DApp 应用设置', 'steem-for-wordpress'),
-      'description' => __('Steem DApp 应用的基本设置，包括 App 主账户、密码等设置', 'steem-for-wordpress'),
+    $settings['dapp'] = array(
+      'title'       => __('DApp 设置', 'steem-for-wordpress'),
+      'description' => __('DApp 应用的基本设置，包括 App 主账户、密码等设置', 'steem-for-wordpress'),
       'fields'      => array(
         array(
           'id'          => 'dapp_account',
-          'label'       => __('Steem DApp 账户', 'steem-for-wordpress'),
-          'description' => __('注册的Steem DApp的主账户，例如 wherein-io', 'steem-for-wordpress'),
+          'label'       => __('DApp 账户', 'steem-for-wordpress'),
+          'description' => __('注册的DApp的主账户，例如 wherein-io', 'steem-for-wordpress'),
           'type'        => 'text',
           'default'     => '',
           'placeholder' => __('dapp-com', 'steem-for-wordpress'),
         ),
         array(
           'id'          => 'dapp_wif',
-          'label'       => __('Steem DApp 账户的发帖密码', 'steem-for-wordpress'),
+          'label'       => __('DApp 账户的发帖密码', 'steem-for-wordpress'),
           'description' => __('此处为发帖密码（posting key），请勿填写 active key, owner key, master key等秘钥', 'steem-for-wordpress'),
           'type'        => 'password',
           'default'     => '',
@@ -221,7 +221,7 @@ class Steem_for_Wordpress_Settings
         ),
         array(
           'id'          => 'dapp_steemid_password',
-          'label'       => __('Steem DApp 的 SteemID 密码', 'steem-for-wordpress'),
+          'label'       => __('DApp 的 SteemID 密码', 'steem-for-wordpress'),
           'description' => __('DApp 需要此密码通过 SteemID 认证用户信息、注册新用户等', 'steem-for-wordpress'),
           'type'        => 'password',
           'default'     => '',
@@ -229,7 +229,7 @@ class Steem_for_Wordpress_Settings
         ),
         array(
           'id'          => 'dapp_steemid_secret',
-          'label'       => __('Steem DApp 的 SteemID 验证秘钥', 'steem-for-wordpress'),
+          'label'       => __('DApp 的 SteemID 验证秘钥', 'steem-for-wordpress'),
           'description' => __('DApp 需要此秘钥通过 SteemID 认证用户信息、注册新用户等', 'steem-for-wordpress'),
           'type'        => 'password',
           'default'     => '',
@@ -237,12 +237,26 @@ class Steem_for_Wordpress_Settings
         ),
         array(
           'id'          => 'dapp_default_tags',
-          'label'       => __('Steem DApp 发帖默认标签', 'steem-for-wordpress'),
-          'description' => __('用Steem DApp发帖时的默认标签，标签由英文、数字和短横（-）组成，标签之间用空格分开', 'steem-for-wordpress'),
+          'label'       => __('DApp 发帖默认标签', 'steem-for-wordpress'),
+          'description' => __('用DApp发帖时的默认标签，标签由英文、数字和短横（-）组成，标签之间用空格分开', 'steem-for-wordpress'),
           'type'        => 'text',
           'default'     => '',
           'placeholder' => __('cn wherein', 'steem-for-wordpress'),
         ),
+        array(
+          'id'          => 'dapp_tags_mapping',
+          'label'       => __('DApp 标签的中英文对应关系', 'steem-for-wordpress'),
+          'description' => __('每行包含标签的英文和中文形式。英文标签将同步到Steem，中文标签在小程序上显示，用逗号、空格或制表符（tab）分开', 'steem-for-wordpress'),
+          'type'        => 'textarea',
+          'default'     => '',
+          'placeholder' => __("life  生活\nphotography  摄影\nart  艺术\nintroduceyourself  自我介绍\ncryptocurrency  加密货币", 'steem-for-wordpress'),
+        ),
+      ),
+    );
+    $settings['api'] = array(
+      'title'       => __('API 设置', 'steem-for-wordpress'),
+      'description' => __('添加您想使用的 Steem API 和对应的权限设置', 'steem-for-wordpress'),
+      'fields'      => array(
         array(
           'id'          => 'api_node_url',
           'label'       => __('Steem API 节点地址', 'steem-for-wordpress'),
@@ -260,13 +274,15 @@ class Steem_for_Wordpress_Settings
           'placeholder' => __('posting key', 'steem-for-wordpress'),
         ),
         array(
-          'id'          => 'dapp_tags_mapping',
-          'label'       => __('Steem DApp 标签的中英文对应关系', 'steem-for-wordpress'),
-          'description' => __('每行包含标签的英文和中文形式。英文标签将同步到Steem，中文标签在小程序上显示，用逗号、空格或制表符（tab）分开', 'steem-for-wordpress'),
-          'type'        => 'textarea',
+          'id'          => 'steem4everyone_password',
+          'label'       => __('Steem4Everyone API 密码', 'steem-for-wordpress'),
+          'description' => __('本地无法安装 php-gmp 扩展时，您可以使用 Steem4Everyone API进行发帖等操作', 'steem-for-wordpress'),
+          'type'        => 'password',
           'default'     => '',
-          'placeholder' => __("life  生活\nphotography  摄影\nart  艺术\nintroduceyourself  自我介绍\ncryptocurrency  加密货币", 'steem-for-wordpress'),
+          'placeholder' => __('password', 'steem-for-wordpress'),
         ),
+      ),
+    );
         // array(
         //   'id'          => 'secret_text_field',
         //   'label'       => __( 'Some Secret Text', 'steem-for-wordpress' ),
@@ -327,8 +343,6 @@ class Steem_for_Wordpress_Settings
         //   ),
         //   'default'     => array( 'circle', 'triangle' ),
         // ),
-      ),
-    );
 
     // $settings['extra'] = array(
     //   'title'       => __( 'Extra', 'steem-for-wordpress' ),

--- a/includes/class-steem-for-wordpress-settings.php
+++ b/includes/class-steem-for-wordpress-settings.php
@@ -262,8 +262,8 @@ class Steem_for_Wordpress_Settings
           'label'       => __('Steem API 节点地址', 'steem-for-wordpress'),
           'description' => __('Steem API 节点的URL，例如 https://steem.61bts.com, https://steemd.minnowsupportproject.org', 'steem-for-wordpress'),
           'type'        => 'text',
-          'default'     => 'https://steemd.minnowsupportproject.org',
-          'placeholder' => __('posting key', 'steem-for-wordpress'),
+          'default'     => 'https://api.steemit.com',
+          'placeholder' => __('api node url', 'steem-for-wordpress'),
         ),
         array(
           'id'          => '2nd_api_node_url',
@@ -271,7 +271,7 @@ class Steem_for_Wordpress_Settings
           'description' => __('Steem 分链的 API 节点的URL，例如 https://anyx.io', 'steem-for-wordpress'),
           'type'        => 'text',
           'default'     => '',
-          'placeholder' => __('posting key', 'steem-for-wordpress'),
+          'placeholder' => __('2nd api node url', 'steem-for-wordpress'),
         ),
         array(
           'id'          => 'steem4everyone_password',

--- a/includes/hooks.php
+++ b/includes/hooks.php
@@ -146,7 +146,7 @@ function steem_publish_post($new_status, $old_status, $post)
         if (!empty($footer)) {
           $footer = str_replace("[%original_link%]", get_permalink($post->ID), $footer);
         }
-        write_log("steem4wp: public post by @{$username}");
+        write_log("steem4wp: publish post by @{$username}");
         write_log($tags);
         write_log("------");
         $steem_ops = new WP_Steem_Ops();

--- a/includes/post_hooks.php
+++ b/includes/post_hooks.php
@@ -1,14 +1,9 @@
 <?php
 /*
- * WordPress Custom API Data Hooks
+ * WordPress Post Publish Hooks
  */
 
 if (!defined('ABSPATH')) exit;
-
-add_filter('user_contactmethods', function ($userInfo) {
-  $userInfo['steemId']         = __('Steem ID');
-  return $userInfo;
-});
 
 // add Steem options for publishing post in user profile page
 add_action('personal_options_update', 'update_steem_user_settings');
@@ -111,6 +106,48 @@ function display_steem_custom_box($post)
   }
 }
 
+
+// ---- Below are post actions ----
+
+// the actual function that perform the sync
+function sync_post_to_steem($post)
+{
+  if (empty($post)) {
+    return ;
+  }
+
+  $user_id = $post->post_author;
+  $posting_key = get_user_meta($user_id, 'user_steem_posting_key', true);
+  $username = get_user_meta($user_id, 'user_steem_id', true);
+
+  if (!empty($posting_key) && !empty($username)) {
+    $tags = wp_get_post_tags($post->ID);
+    if (empty($tags)) {
+      $tags = get_user_meta($user_id, 'user_steem_default_tags', true);
+      if (!empty($tags) && is_string($tags)) {
+        $tags = strtolower($tags);
+        $tags = wp_parse_list($tags);
+      }
+    } else {
+      $tags_arr = [];
+      foreach ($tags as $t) {
+        $tags_arr[] = str_replace(" ", "", $t->name);
+      }
+      $tags = $tags_arr;
+    }
+    $footer = get_user_meta($user_id, 'user_steem_footer', true);
+    if (!empty($footer)) {
+      $footer = str_replace("[%original_link%]", get_permalink($post->ID), $footer);
+    }
+    write_log("steem4wp: publish post by @{$username}");
+    write_log($tags);
+    write_log("------");
+    $steem_ops = new WP_Steem_Ops();
+    $steem_ops->create_post($username, $post->ID, $tags, $footer);
+  }
+  return;
+}
+
 // add hook for publishing to Steem
 add_action('transition_post_status', 'steem_publish_post', 15, 3);
 function steem_publish_post($new_status, $old_status, $post)
@@ -125,33 +162,7 @@ function steem_publish_post($new_status, $old_status, $post)
     if (!isset($_POST['user_steem_publish_post']) && isset($_POST['user_steem_not_publish_post'])) {
       return;
     } else {
-      $posting_key = get_user_meta(get_current_user_id(), 'user_steem_posting_key', true);
-      $username = get_user_meta(get_current_user_id(), 'user_steem_id', true);
-      if (!empty($posting_key) && !empty($username)) {
-        $tags = wp_get_post_tags($post->ID);
-        if (empty($tags)) {
-          $tags = get_user_meta(get_current_user_id(), 'user_steem_default_tags', true);
-          if (!empty($tags) && is_string($tags)) {
-            $tags = strtolower($tags);
-            $tags = wp_parse_list($tags);
-          }
-        } else {
-          $tags_arr = [];
-          foreach ($tags as $t) {
-            $tags_arr[] = str_replace(" ", "", $t->name);
-          }
-          $tags = $tags_arr;
-        }
-        $footer = get_user_meta(get_current_user_id(), 'user_steem_footer', true);
-        if (!empty($footer)) {
-          $footer = str_replace("[%original_link%]", get_permalink($post->ID), $footer);
-        }
-        write_log("steem4wp: publish post by @{$username}");
-        write_log($tags);
-        write_log("------");
-        $steem_ops = new WP_Steem_Ops();
-        $steem_ops->create_post($username, $post->ID, $tags, $footer);
-      }
+      sync_post_to_steem($post);
       return;
     }
   }
@@ -166,4 +177,55 @@ function steem_publish_post($new_status, $old_status, $post)
   // }
 
   return;
+}
+
+// add hook for scheduling future post
+add_action('publish_future_post', 'steem_publish_future_post');
+// add_action('future_to_publish', 'steem_publish_future_post');
+function steem_publish_future_post($post_id)
+{
+  // if the publish to steem checkbox is checked
+  $value = get_post_meta($post_id, 'user_steem_publish_post', true);
+  write_log("publish_future_post: id = ${post_id}; sync_to_steem = ${value}");
+
+  if ($value != "0") {
+    $post = get_post($post_id);
+    sync_post_to_steem($post);
+  }
+}
+
+// click save post button
+add_action('save_post', 'steem_save_post', 8);
+function steem_save_post($post_id)
+{
+  if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE || !current_user_can('edit_post', $post_id) || $_POST == [])
+    return;
+
+  if (isset($_POST['user_steem_publish_post']) || isset($_POST['user_steem_not_publish_post'])) {
+    if ($_POST['user_steem_publish_post'] === '1') {
+      // If post is empty/ doesn't have the hidden_mm attribute this means that we are using gutenberg
+      // if ($_POST == [] || !isset($_POST['hidden_mm'])) {
+      //   if (get_post_meta($post_id, 'steem_author', true) == "" && get_post_status($post_id) == 'publish') {
+      //     $post = get_post($post_id);
+      //     sync_post_to_steem($post);
+      //   }
+      // }
+      update_post_meta($post_id, 'user_steem_publish_post', '1');
+    } else {
+      update_post_meta($post_id, 'user_steem_publish_post', '0');
+    }
+  }
+
+  // if (isset($_POST['user_steem_update_post'])) {
+  //   if ($_POST['user_steem_update_post'] === '1') {
+  //     // If post is empty/ doesn't have the hidden_mm attribute this means that we are using gutenberg
+  //     if ($_POST == [] || !isset($_POST['hidden_mm'])) {
+  //       $post = get_post($post_id);
+  //       sync_post_to_steem($post_id);
+  //     }
+  //     update_post_meta($post_id, 'user_steem_update_post', $_POST['user_steem_update_post']);
+  //   } else {
+  //     update_post_meta($post_id, 'user_steem_update_post', '0');
+  //   }
+  // }
 }

--- a/includes/router.php
+++ b/includes/router.php
@@ -10,7 +10,8 @@ include(STEEM_REST_API_DIR . 'includes/comment.php');
 include(STEEM_REST_API_DIR . 'includes/vote.php');
 include(STEEM_REST_API_DIR . 'includes/user.php');
 include(STEEM_REST_API_DIR . 'includes/settings.php');
-include(STEEM_REST_API_DIR . 'includes/hooks.php');
+include(STEEM_REST_API_DIR . 'includes/user_hooks.php');
+include(STEEM_REST_API_DIR . 'includes/post_hooks.php');
 
 add_action('rest_api_init', function () {
   $controls = array();

--- a/includes/router.php
+++ b/includes/router.php
@@ -3,6 +3,7 @@
 if (!defined('ABSPATH')) exit;
 
 include(STEEM_REST_API_DIR . 'includes/steemid.php');
+include(STEEM_REST_API_DIR . 'includes/steem4everyone.php');
 include(STEEM_REST_API_DIR . 'includes/auth.php');
 include(STEEM_REST_API_DIR . 'includes/post.php');
 include(STEEM_REST_API_DIR . 'includes/comment.php');

--- a/includes/steem.php
+++ b/includes/steem.php
@@ -105,14 +105,10 @@ class Steem
       $user_id = get_current_user_id();
     }
     if (empty($user_id) && !empty($account)) {
-      $user_query = new WP_User_Query(array('meta_key' => 'steemId', 'meta_value' => $account));
-      $users = $user_query->get_results();
-      if (!empty($users) && is_array($users) && count($users) > 0) {
-        $user = $users[0];
-        if (!empty($user)) {
-          $user_id = $user->ID;
-        }
-      }
+      $user_id = $this->queryUserIdByField('steemId', $account);
+    }
+    if (empty($user_id) && !empty($account)) {
+      $user_id = $this->queryUserIdByField('user_steem_id', $account);
     }
     if (empty($wif) && !empty($user_id)) {
       $wif = get_user_meta($user_id, 'user_steem_posting_key', true);
@@ -124,6 +120,19 @@ class Steem
       $wif = getenv('STEEM_DAPP_WIF');
     }
     return $wif;
+  }
+
+  protected function queryUserIdByField($key, $value)
+  {
+    $user_query = new WP_User_Query(array('meta_key' => $key, 'meta_value' => $value));
+    $users = $user_query->get_results();
+    if (!empty($users) && is_array($users) && count($users) > 0) {
+      $user = $users[0];
+      if (!empty($user)) {
+        return $user->ID;
+      }
+    }
+    return null;
   }
 
   protected function canBroadcastLocally()

--- a/includes/steem.php
+++ b/includes/steem.php
@@ -99,7 +99,24 @@ class Steem
    */
   protected function getWif($account)
   {
-    $wif = get_user_meta( get_current_user_id(), 'user_steem_posting_key', true );
+    $wif = null;
+    $user_id = null;
+    if (function_exists('get_current_user_id')) {
+      $user_id = get_current_user_id();
+    }
+    if (empty($user_id) && !empty($account)) {
+      $user_query = new WP_User_Query(array('meta_key' => 'steemId', 'meta_value' => $account));
+      $users = $user_query->get_results();
+      if (!empty($users) && is_array($users) && count($users) > 0) {
+        $user = $users[0];
+        if (!empty($user)) {
+          $user_id = $user->ID;
+        }
+      }
+    }
+    if (empty($wif) && !empty($user_id)) {
+      $wif = get_user_meta($user_id, 'user_steem_posting_key', true);
+    }
     if (empty($wif) && function_exists('get_option')) {
       $wif = get_option("steem_dapp_wif");
     }

--- a/includes/steem4everyone.php
+++ b/includes/steem4everyone.php
@@ -34,7 +34,7 @@ class Steem4Everyone
   {
     if (function_exists('get_option')) {
       // $dapp_id = get_option('steem_dapp_account');
-      $dapp_password = get_option('steem_dapp_steemid_password');
+      $dapp_password = get_option('steem_steem4everyone_password');
       $body['dapp_password'] = $dapp_password;
       // $dapp_secret = get_option('steem_dapp_steemid_secret');
     }

--- a/includes/steem4everyone.php
+++ b/includes/steem4everyone.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * REST API: WP_REST_Authentication_Controller class
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 4.7.0
+ */
+if (!defined('ABSPATH')) exit;
+
+class Steem4Everyone
+{
+
+  protected static $steem4everyone_base_url = 'https://steem4everyone-api.herokuapp.com/api';
+
+  protected $node;
+
+  /**
+   * Initialize the connection to the host
+   *
+   * @param      string  $node   The node you want to connect
+   */
+  public function __construct($node = null)
+  {
+    if (!empty($node)) {
+      $this->node = trim($node);
+    } else {
+      $this->node = null;
+    }
+  }
+
+  public function send($endpoint, $body)
+  {
+    if (function_exists('get_option')) {
+      // $dapp_id = get_option('steem_dapp_account');
+      $dapp_password = get_option('steem_dapp_steemid_password');
+      $body['dapp_password'] = $dapp_password;
+      // $dapp_secret = get_option('steem_dapp_steemid_secret');
+    }
+    // if (empty($dapp_id) || empty($dapp_password) || empty($dapp_secret)) {
+    //   return null;
+    // }
+
+    if (!empty($this->node)) {
+      $body['api_url'] = $this->node;
+    }
+
+    global $wp_version;
+    $args = array(
+      'method'      => 'POST',
+      'timeout'     => 60,
+      'redirection' => 5,
+      'httpversion' => '1.0',
+      'blocking'    => true,
+      'headers'     => array(
+        'Referer' => get_bloginfo('url'),
+        'Origin'  => get_bloginfo('url'),
+      ),
+      'body'        => $body,
+      'cookies'     => array(),
+      'user-agent' => 'WordPress/' . $wp_version . '; ' . get_bloginfo('url')
+    );
+
+    $response = wp_remote_post(Steem4Everyone::$steem4everyone_base_url . $endpoint, $args);
+
+    if (is_wp_error($response)) {
+      return null;
+    } else {
+      $body = wp_remote_retrieve_body($response);
+      $data = json_decode($body, true);
+      return $data;
+    }
+  }
+
+  /**
+   * Broadcast the operation to Steem blockchain
+   */
+  public function broadcast($user, $operation, $params)
+  {
+    $res = $this->send('/broadcast', [
+      'user' => $user,
+      'operations' => json_encode([[$operation, $params]])
+    ]);
+    if (array_key_exists('result', $res) && !empty($res['result'])) {
+      return $res['result'];
+    } else {
+      return $res;
+    }
+  }
+
+  /**
+   * Create a comment on Steem
+   */
+  public function comment($parentAuthor, $parentPermlink, $author, $permlink, $title, $body, $jsonMetadata)
+  {
+    return $this->broadcast($author, 'comment', [
+      'parent_author' => $parentAuthor,
+      'parent_permlink' => $parentPermlink,
+      'author' => $author,
+      'permlink' => $permlink,
+      'title' => $title,
+      'body' => $body,
+      'json_metadata' => json_encode($jsonMetadata)
+    ]);
+  }
+
+  /**
+   * Get the profile info of the current account
+   */
+  public function me($user)
+  {
+    return $this->send('/me', [
+      'user' => $user
+    ]);
+  }
+
+}

--- a/includes/user_hooks.php
+++ b/includes/user_hooks.php
@@ -1,0 +1,11 @@
+<?php
+/*
+ * WordPress Custom API Data Hooks
+ */
+
+if (!defined('ABSPATH')) exit;
+
+add_filter('user_contactmethods', function ($userInfo) {
+  $userInfo['steemId']         = __('Steem ID');
+  return $userInfo;
+});


### PR DESCRIPTION
### Description

1. fallback to steem4everyone remote call when PHP GMP lib is not available in the machine
2. add Steem posting support for scheduled post in wordpress

### UI Change

- split the menu items into two tabs: **DApp** and **API**

![image](https://user-images.githubusercontent.com/46699230/81472189-f087cc00-9228-11ea-9235-67b87f439526.png)

![image](https://user-images.githubusercontent.com/46699230/81472192-f8e00700-9228-11ea-8de0-884a5dc0cd97.png)
